### PR TITLE
Implement header/footer and JS validation

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1,0 +1,8 @@
+body {
+    font-family: Arial, sans-serif;
+    color: #333;
+}
+
+h2 {
+    color: #007bff;
+}

--- a/src/main/resources/static/js/validation.js
+++ b/src/main/resources/static/js/validation.js
@@ -1,0 +1,49 @@
+$(document).ready(function(){
+  $('form').on('submit', function(e){
+    var valid = true;
+    var form = $(this);
+    var phone = form.find('input[name$="sodt"]');
+    if(phone.length && !/^(090\d{7}|091\d{7}|\(84\)\+90\d{7}|\(84\)\+91\d{7})$/.test(phone.val())){
+      alert('Số điện thoại không hợp lệ');
+      valid = false;
+    }
+    var email = form.find('input[type="email"]');
+    if(email.length && !/^\S+@\S+\.\S+$/.test(email.val())){
+      alert('Email không hợp lệ');
+      valid = false;
+    }
+    var soLuong = form.find('input[name$="soLuong"],input[name$="thoiGianSuDung"],input[name$="donGia"]');
+    soLuong.each(function(){
+      if($(this).val() && !/^[1-9]\d*$/.test($(this).val())){
+        alert('Giá trị phải là số nguyên dương');
+        valid = false;
+      }
+    });
+    var gio = form.find('input[type="time"]');
+    gio.each(function(){
+      if($(this).val() && !/^([01]\d|2[0-3]):[0-5]\d$/.test($(this).val())){
+        alert('Định dạng giờ không hợp lệ');
+        valid = false;
+      }
+    });
+    var maKH = form.find('input[name$="maKH"]');
+    if(maKH.length && !/^KH\d{5}$/.test(maKH.val())){
+      alert('Mã KH không hợp lệ');
+      valid = false;
+    }
+    var maDV = form.find('input[name$="maDV"]');
+    if(maDV.length && !/^DV\d{3}$/.test(maDV.val())){
+      alert('Mã DV không hợp lệ');
+      valid = false;
+    }
+    if(!valid){
+      e.preventDefault();
+    }
+  });
+
+  $('.delete-link').on('click', function(e){
+    if(!confirm('Bạn có chắc muốn xóa?')){
+      e.preventDefault();
+    }
+  });
+});

--- a/src/main/resources/templates/dichvu/DichVuCreate.html
+++ b/src/main/resources/templates/dichvu/DichVuCreate.html
@@ -6,6 +6,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
+<div th:replace="fragments/nav :: nav"></div>
 <div class="container mt-4">
     <h2 class="mb-4">Thêm dịch vụ mới</h2>
     <form th:action="@{/dichvu/save}" th:object="${dichvu}" method="post">
@@ -29,5 +30,6 @@
         <a th:href="@{/dichvu}" class="btn btn-secondary">Hủy</a>
     </form>
 </div>
+<div th:replace="fragments/footer :: footer"></div>
 </body>
 </html>

--- a/src/main/resources/templates/dichvu/DichVuEdit.html
+++ b/src/main/resources/templates/dichvu/DichVuEdit.html
@@ -6,6 +6,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
+<div th:replace="fragments/nav :: nav"></div>
 <div class="container mt-4">
     <h2 class="mb-4">Sửa thông tin dịch vụ</h2>
     <form th:action="@{'/dichvu/update/' + ${dichvu.maDV}}" th:object="${dichvu}" method="post">
@@ -29,5 +30,6 @@
         <a th:href="@{/dichvu}" class="btn btn-secondary">Quay lại</a>
     </form>
 </div>
+<div th:replace="fragments/footer :: footer"></div>
 </body>
 </html>

--- a/src/main/resources/templates/dichvu/DichVuList.html
+++ b/src/main/resources/templates/dichvu/DichVuList.html
@@ -6,6 +6,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
+<div th:replace="fragments/nav :: nav"></div>
 <div class="container mt-4">
     <h2 class="mb-4">Danh sách Dịch vụ</h2>
     <a class="btn btn-success mb-3" th:href="@{/dichvu/create}">Thêm mới</a>
@@ -28,8 +29,7 @@
             <td>
                 <a th:href="@{'/dichvu/edit/' + ${dv.maDV}}" class="btn btn-primary btn-sm">Sửa</a>
                 <a th:href="@{'/dichvu/delete/' + ${dv.maDV}}"
-                   class="btn btn-danger btn-sm"
-                   onclick="return confirm('Bạn có chắc muốn xóa?')">Xóa</a>
+                   class="btn btn-danger btn-sm delete-link">Xóa</a>
             </td>
         </tr>
         </tbody>
@@ -52,5 +52,6 @@
 
 
 </div>
+<div th:replace="fragments/footer :: footer"></div>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -1,0 +1,7 @@
+<div th:fragment="footer">
+    <footer class="bg-light text-center py-3 mt-4">
+      <div class="container">
+        <span class="text-muted">© 2024 QuanNet</span>
+      </div>
+    </footer>
+</div>

--- a/src/main/resources/templates/fragments/nav.html
+++ b/src/main/resources/templates/fragments/nav.html
@@ -1,0 +1,25 @@
+<div th:fragment="nav">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+    <script th:src="@{/js/validation.js}"></script>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+      <div class="container-fluid">
+        <a class="navbar-brand" th:href="@{/}">QuanNet</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+          <ul class="navbar-nav">
+            <li class="nav-item"><a class="nav-link" th:href="@{/may}">Máy</a></li>
+            <li class="nav-item"><a class="nav-link" th:href="@{/khachhang}">Khách hàng</a></li>
+            <li class="nav-item"><a class="nav-link" th:href="@{/dichvu}">Dịch vụ</a></li>
+            <li class="nav-item"><a class="nav-link" th:href="@{/sudungmay/create}">Sử dụng máy</a></li>
+            <li class="nav-item"><a class="nav-link" th:href="@{/sudungdichvu/create}">Sử dụng dịch vụ</a></li>
+            <li class="nav-item"><a class="nav-link" th:href="@{/thongtinsd}">Thông tin</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+</div>

--- a/src/main/resources/templates/khachhang/KhachHangCreate.html
+++ b/src/main/resources/templates/khachhang/KhachHangCreate.html
@@ -6,6 +6,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
+<div th:replace="fragments/nav :: nav"></div>
 <div class="container mt-4">
     <h2 class="mb-4">Thêm khách hàng mới</h2>
     <form th:action="@{/khachhang/save}" th:object="${khachhang}" method="post">
@@ -29,5 +30,6 @@
         <a th:href="@{/khachhang}" class="btn btn-secondary">Hủy</a>
     </form>
 </div>
+<div th:replace="fragments/footer :: footer"></div>
 </body>
 </html>

--- a/src/main/resources/templates/khachhang/KhachHangEdit.html
+++ b/src/main/resources/templates/khachhang/KhachHangEdit.html
@@ -6,6 +6,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
+<div th:replace="fragments/nav :: nav"></div>
 <div class="container mt-4">
     <h2 class="mb-4">Sửa thông tin khách hàng</h2>
     <form th:action="@{'/khachhang/update/' + ${khachhang.maKH}}" th:object="${khachhang}" method="post">
@@ -29,5 +30,6 @@
         <a th:href="@{/khachhang}" class="btn btn-secondary">Quay lại</a>
     </form>
 </div>
+<div th:replace="fragments/footer :: footer"></div>
 </body>
 </html>

--- a/src/main/resources/templates/khachhang/KhachHangList.html
+++ b/src/main/resources/templates/khachhang/KhachHangList.html
@@ -6,6 +6,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
+<div th:replace="fragments/nav :: nav"></div>
 <div class="container mt-4">
     <h2 class="mb-4">Danh sách khách hàng</h2>
     <a class="btn btn-success mb-3" th:href="@{/khachhang/create}">Thêm mới</a>
@@ -28,8 +29,7 @@
             <td>
                 <a th:href="@{'/khachhang/edit/' + ${kh.maKH}}" class="btn btn-primary btn-sm">Sửa</a>
                 <a th:href="@{'/khachhang/delete/' + ${kh.maKH}}"
-                   class="btn btn-danger btn-sm"
-                   onclick="return confirm('Bạn có chắc muốn xóa?')">Xóa</a>
+                   class="btn btn-danger btn-sm delete-link">Xóa</a>
             </td>
         </tr>
         </tbody>
@@ -52,5 +52,6 @@
 
 
 </div>
+<div th:replace="fragments/footer :: footer"></div>
 </body>
 </html>

--- a/src/main/resources/templates/may/MayCreate.html
+++ b/src/main/resources/templates/may/MayCreate.html
@@ -6,6 +6,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
+<div th:replace="fragments/nav :: nav"></div>
 <div class="container mt-4">
     <h2 class="mb-4">Thêm Máy</h2>
     <form th:action="@{/may/save}" th:object="${may}" method="post">
@@ -25,5 +26,6 @@
         <a th:href="@{/may}" class="btn btn-secondary">Hủy</a>
     </form>
 </div>
+<div th:replace="fragments/footer :: footer"></div>
 </body>
 </html>

--- a/src/main/resources/templates/may/MayEdit.html
+++ b/src/main/resources/templates/may/MayEdit.html
@@ -6,6 +6,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
+<div th:replace="fragments/nav :: nav"></div>
 <div class="container mt-4">
     <h2 class="mb-4">Sửa thông tin Máy</h2>
     <form th:action="@{'/may/update/' + ${may.maMay}}" th:object="${may}" method="post">
@@ -26,5 +27,6 @@
         <a th:href="@{/may}" class="btn btn-secondary">Quay lại</a>
     </form>
 </div>
+<div th:replace="fragments/footer :: footer"></div>
 </body>
 </html>

--- a/src/main/resources/templates/may/MayList.html
+++ b/src/main/resources/templates/may/MayList.html
@@ -6,6 +6,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
+<div th:replace="fragments/nav :: nav"></div>
 <div class="container mt-4">
     <h2 class="mb-4">Danh sách May</h2>
     <a class="btn btn-success mb-3" th:href="@{/may/create}">Thêm mới</a>
@@ -26,8 +27,7 @@
             <td>
                 <a th:href="@{'/may/edit/' + ${kh.maMay}}" class="btn btn-primary btn-sm">Sửa</a>
                 <a th:href="@{'/may/delete/' + ${kh.maMay}}"
-                   class="btn btn-danger btn-sm"
-                   onclick="return confirm('Bạn có chắc muốn xóa?')">Xóa</a>
+                   class="btn btn-danger btn-sm delete-link">Xóa</a>
             </td>
         </tr>
         </tbody>
@@ -50,5 +50,6 @@
 
 
 </div>
+<div th:replace="fragments/footer :: footer"></div>
 </body>
 </html>

--- a/src/main/resources/templates/sudungdichvu/SuDungDichVuCreate.html
+++ b/src/main/resources/templates/sudungdichvu/SuDungDichVuCreate.html
@@ -6,6 +6,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
+<div th:replace="fragments/nav :: nav"></div>
 <div class="container mt-4">
     <h2 class="mb-4">Đăng ký sử dụng dịch vụ</h2>
     <form th:action="@{/sudungdichvu/save}" th:object="${suDungDichVu}" method="post">
@@ -39,5 +40,6 @@
         <a th:href="@{/sudungdichvu/create}" class="btn btn-secondary">Hủy</a>
     </form>
 </div>
+<div th:replace="fragments/footer :: footer"></div>
 </body>
 </html>

--- a/src/main/resources/templates/sudungmay/SuDungMayCreate.html
+++ b/src/main/resources/templates/sudungmay/SuDungMayCreate.html
@@ -6,6 +6,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
+<div th:replace="fragments/nav :: nav"></div>
 <div class="container mt-4">
     <h2 class="mb-4">Đăng ký sử dụng máy</h2>
     <form th:action="@{/sudungmay/save}" th:object="${suDungMay}" method="post">
@@ -39,5 +40,6 @@
         <a th:href="@{/sudungmay/create}" class="btn btn-secondary">Hủy</a>
     </form>
 </div>
+<div th:replace="fragments/footer :: footer"></div>
 </body>
 </html>

--- a/src/main/resources/templates/thongtinsudung/thongtinsudung.html
+++ b/src/main/resources/templates/thongtinsudung/thongtinsudung.html
@@ -6,6 +6,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
+<div th:replace="fragments/nav :: nav"></div>
 <div class="container mt-4">
     <h2>Thông tin khách hàng, máy, dịch vụ đã sử dụng</h2>
     <table class="table table-bordered table-hover">
@@ -60,5 +61,6 @@
         </ul>
     </nav>
 </div>
+<div th:replace="fragments/footer :: footer"></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add navigation and footer fragments
- load shared CSS and JS with validation logic
- update all HTML templates to include new nav/footer
- implement delete confirmation via JS
- apply basic styling

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f940cd7c8333b5fe00ef9b5bf035